### PR TITLE
Support the uppercase SConstruct variant

### DIFF
--- a/lib/scons.js
+++ b/lib/scons.js
@@ -66,9 +66,10 @@ export function provideBuilder() {
       console.log("scons build dir: " + this.build);
 
       atom.config.observe('build-scons.silentMode', () => this.emit('refresh'));
+      atom.config.observe('build-scons.silentSconsMode', () => this.emit('refresh'));
       atom.config.observe('build-scons.numJobs', () => this.emit('refresh'));
       atom.config.observe('build-scons.separateBuildDir', () => this.emit('refresh'));
-
+      
       var utfile = new File(path.join(this.src, "targets.ini"));
       utfile.onDidChange(() => this.emit('refresh'));
     }

--- a/lib/scons.js
+++ b/lib/scons.js
@@ -75,7 +75,7 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      this.files = ['sconstruct']
+      this.files = ['sconstruct', 'SConstruct']
         .map(f => path.join(this.src, f))
         .filter(fs.existsSync);
       return this.files.length > 0;

--- a/lib/scons.js
+++ b/lib/scons.js
@@ -17,6 +17,13 @@ export const config = {
     default: true,
     order: 10
   },
+  silentSconsMode: {
+    title: 'silence Scons',
+    description: 'Don\'t print Scons commands.',
+    type: 'boolean',
+    default: true,
+    order: 15
+  },
   numJobs: {
     title: 'jobs',
     description: 'Number of jobs to run in parallel.',
@@ -142,6 +149,8 @@ export function provideBuilder() {
 
       if(atom.config.get('build-scons.silentMode')) {
         common_args = common_args.concat('-s');
+      } else if (atom.config.get('build-scons.silentSconsMode')) {
+        common_args = common_args.concat('-Q');
       }
 
       common_args = common_args.concat(['-j', atom.config.get('build-scons.numJobs')]);


### PR DESCRIPTION
Should be more open to different variations on the capitalization of the sconstruct file. I guess there should be a toLower or something before the check. But as far as I can see the 'fs.existsSync' does the real check and needs the proper case of the file.